### PR TITLE
Automatically switch protocol versions to find the best one

### DIFF
--- a/custom_updater.json
+++ b/custom_updater.json
@@ -1,6 +1,6 @@
 {
     "goldair_climate": {
-        "version": "0.0.6",
+        "version": "0.0.7",
         "local_location": "/custom_components/goldair_climate/__init__.py",
         "remote_location": "https://raw.githubusercontent.com/nikrolls/homeassistant-goldair-climate/master/custom_components/goldair_climate/__init__.py",
         "visit_repo": "https://github.com/nikrolls/homeassistant-goldair-climate",


### PR DESCRIPTION
There are two protocol versions that Goldair devices may use. Rather than requiring that the user know which one and put it in the config, a more automatic solution is to just switch the version when there is a communication error. There may be some false positives when network connectivity is low, but it's a much nicer solution than putting it on the user.