### PR TITLE
Avoid switching protocols once communication is working

### DIFF
--- a/custom_components/goldair_climate/device.py
+++ b/custom_components/goldair_climate/device.py
@@ -207,7 +207,7 @@ class GoldairTuyaDevice(object):
                     self._reset_cached_state()
                     self._api_protocol_working = False
                     _LOGGER.error(error_message)
-                else:
+                elif self._api_protocol_working is False:
                     self._rotate_api_protocol_version()
 
     def _get_cached_state(self):
@@ -229,7 +229,7 @@ class GoldairTuyaDevice(object):
     def _rotate_api_protocol_version(self):
         if self._api_protocol_version_index is None:
             self._api_protocol_version_index = 0
-        elif self._api_protocol_working is False:
+        else:
             self._api_protocol_version_index += 1
 
         if self._api_protocol_version_index >= len(API_PROTOCOL_VERSIONS):

--- a/custom_components/goldair_climate/device.py
+++ b/custom_components/goldair_climate/device.py
@@ -37,6 +37,7 @@ class GoldairTuyaDevice(object):
 
         self._name = name
         self._api_protocol_version_index = None
+        self._api_protocol_working = False
         self._api = pytuya.Device(dev_id, address, local_key, "device")
         self._refresh_task = None
         self._rotate_api_protocol_version()
@@ -198,11 +199,13 @@ class GoldairTuyaDevice(object):
         for i in range(self._CONNECTION_ATTEMPTS):
             try:
                 func()
+                self._api_protocol_working = True
                 break
             except Exception as e:
                 _LOGGER.debug(f"Retrying after exception {e}")
                 if i + 1 == self._CONNECTION_ATTEMPTS:
                     self._reset_cached_state()
+                    self._api_protocol_working = False
                     _LOGGER.error(error_message)
                 else:
                     self._rotate_api_protocol_version()
@@ -226,7 +229,7 @@ class GoldairTuyaDevice(object):
     def _rotate_api_protocol_version(self):
         if self._api_protocol_version_index is None:
             self._api_protocol_version_index = 0
-        else:
+        elif self._api_protocol_working is False:
             self._api_protocol_version_index += 1
 
         if self._api_protocol_version_index >= len(API_PROTOCOL_VERSIONS):

--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -219,9 +219,7 @@ class TestDevice(IsolatedAsyncioTestCase):
         self.subject.refresh()
         self.subject.refresh()
 
-        self.subject._api.set_version.assert_has_calls(
-            [call(3.1), call(3.3)]
-        )
+        self.subject._api.set_version.assert_has_calls([call(3.1), call(3.3)])
 
     def test_reset_cached_state_clears_cached_state_and_pending_updates(self):
         self.subject._cached_state = {"1": True, "updated_at": time()}

--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -202,6 +202,27 @@ class TestDevice(IsolatedAsyncioTestCase):
             [call(3.1), call(3.3), call(3.1)]
         )
 
+    def test_api_protocol_version_is_stable_once_successful(self):
+        self.subject._api.set_version.assert_called_once_with(3.3)
+        self.subject._api.set_version.reset_mock()
+
+        self.subject._api.status.side_effect = [
+            {"dps": {"1": False}},
+            Exception("Error"),
+            Exception("Error"),
+            Exception("Error"),
+            Exception("Error"),
+            Exception("Error"),
+            Exception("Error"),
+        ]
+        self.subject.refresh()
+        self.subject.refresh()
+        self.subject.refresh()
+
+        self.subject._api.set_version.assert_has_calls(
+            [call(3.3), call(3.3), call(3.3), call(3.1), call(3.3)]
+        )
+
     def test_reset_cached_state_clears_cached_state_and_pending_updates(self):
         self.subject._cached_state = {"1": True, "updated_at": time()}
         self.subject._pending_updates = {"1": False}

--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -220,7 +220,7 @@ class TestDevice(IsolatedAsyncioTestCase):
         self.subject.refresh()
 
         self.subject._api.set_version.assert_has_calls(
-            [call(3.3), call(3.3), call(3.3), call(3.1), call(3.3)]
+            [call(3.1), call(3.3)]
         )
 
     def test_reset_cached_state_clears_cached_state_and_pending_updates(self):


### PR DESCRIPTION
1. Once communication is working to a device, be less eager to change the protocol.

Improves issue #30 and #36.